### PR TITLE
add input for logging verbosity

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,13 @@ inputs:
 
       Use of invite codes is DEPRECATED, use identity instead.
     required: false
+  
+  verbosity:
+    description: |
+      Set the logging verbosity for chainctl. A value of 0 disables
+      logging output. Valid values are 1-5, increasing in verbosity.
+    required: false
+    default: 0
 
 runs:
   using: "composite"
@@ -57,13 +64,13 @@ runs:
       env:
         CHAINCTL_DEBUG: "true"
       run: |
-        if chainctl auth login --identity "${{ inputs.identity }}"; then
+        if chainctl auth login --identity "${{ inputs.identity }}" -v=${{ inputs.verbosity }}; then
           echo Logged in as ${{ inputs.identity }}!
         else
           echo Unable to assume the identity ${{ inputs.identity }}.
           exit 1
         fi
-        if ! chainctl auth configure-docker --identity "${{ inputs.identity }}"; then
+        if ! chainctl auth configure-docker --identity "${{ inputs.identity }}" -v=${{ inputs.verbosity }}; then
           echo Unable to register credential helper as ${{ inputs.identity }}.
           exit 1
         fi
@@ -84,7 +91,7 @@ runs:
         IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${AUDIENCE}" | jq -r '.value')
 
         # This will start failing once the invite code expires, which is why we have the login guard.
-        if chainctl auth login --create-group=false --identity-token "${IDTOKEN}" --invite-code="${CHAINGUARD_INVITE_CODE}"; then
+        if chainctl auth login --create-group=false --identity-token "${IDTOKEN}" --invite-code="${CHAINGUARD_INVITE_CODE}" -v=${{ inputs.verbosity }}; then
           echo Logged in!
         else
           echo Failed to log in with invite code
@@ -106,7 +113,7 @@ runs:
         fi
         IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${AUDIENCE}" | jq -r '.value')
 
-        if chainctl auth login --identity-token "${IDTOKEN}"; then
+        if chainctl auth login --identity-token "${IDTOKEN}" -v=${{ inputs.verbosity }}; then
           echo Logged in!
         else
           echo No invite code is present!  Failing since registration will not do any good.


### PR DESCRIPTION
Add the option to provide a logging verbosity to `chainctl` commands. Default is `0` (disabled).