### PR TITLE
Enable retry-all-errors by default

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -60,9 +60,9 @@ inputs:
 
   retry-all-errors:
     description: |
-      Whether to retry on all errors.
+      Whether to retry on errors downloading the chainctl binary.
     required: false
-    default: false
+    default: true
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary
- Changes the default value of `retry-all-errors` from `false` to `true`
- Updates description to clarify it applies to downloading the chainctl binary
- Makes the action more resilient to transient download failures by default

🤖 Generated with [Claude Code](https://claude.ai/code)