### PR TITLE
fix apk.cgr.dev replacement

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -130,7 +130,7 @@ runs:
         fi
         echo "::endgroup::"
 
-        echo "::group::Authenticating with apk.cgr.dev as ${{ env.IDENTITY }}"
+        echo "::group::Authenticating with ${{ inputs.apk-host }} as ${{ env.IDENTITY }}"
         if ! chainctl auth login --identity "${{ env.IDENTITY }}" --audience ${{ inputs.apk-host }} -v=${{ env.VERBOSITY }}; then
           echo "::error Unable to assume the identity ${{ env.IDENTITY }} for ${{ inputs.apk-host }}."
           exit 1
@@ -146,7 +146,7 @@ runs:
 
         if [ "${{ env.EXPORT_AUTH }}" == "true" ]; then
           echo "::group::Exporting HTTP_AUTH environment variable for ${{ inputs.apk-host }}"
-          echo HTTP_AUTH="basic:apk.cgr.dev:user:$(chainctl auth token --audience ${{ inputs.apk-host }})" >> $GITHUB_ENV
+          echo HTTP_AUTH="basic:${{ inputs.apk-host }}:user:$(chainctl auth token --audience ${{ inputs.apk-host }})" >> $GITHUB_ENV
           echo "::endgroup::"
         fi
 


### PR DESCRIPTION
Didn't get all of them in the merge.

This is a bug fix because we need to make sure to replace the proper host prefix for the HTTP_AUTH creds.