### PR TITLE
 fix: add --headless to prevent browser opening on auth failure in CI

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -135,7 +135,7 @@ runs:
         EXPORT_AUTH: ${{ inputs.env-auth }}
       run: |
         echo "::group::Authenticating with Chainguard as ${{ env.IDENTITY }}"
-        if chainctl auth login --identity "${{ env.IDENTITY }}" -v=${{ env.VERBOSITY }}; then
+        if chainctl auth login --headless --identity "${{ env.IDENTITY }}" -v=${{ env.VERBOSITY }}; then
           echo Logged in as ${{ env.IDENTITY }}!
         else
           echo "::error Unable to assume the identity ${{ env.IDENTITY }}."
@@ -158,7 +158,7 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Registering docker credential helper"
-        if ! chainctl auth configure-docker --identity "${{ env.IDENTITY }}" -v=${{ env.VERBOSITY }}; then
+        if ! chainctl auth configure-docker --headless --identity "${{ env.IDENTITY }}" -v=${{ env.VERBOSITY }}; then
           echo "::error Unable to register credential helper as ${{ env.IDENTITY }}."
           exit 1
         fi


### PR DESCRIPTION
  ## Summary

  Add `--headless` flag to `chainctl auth login` and
  `chainctl auth configure-docker` commands in the action. This prevents
  chainctl from attempting to open a browser window when authentication
  fails in CI, which hangs the workflow indefinitely.

  ## Problem

  When `setup-chainctl` fails (e.g., identity name passed instead of UIDP,
  misconfigured identity, missing `id-token: write` permission), `chainctl`
  falls back to browser-based authentication. In GitHub Actions, there is
  no browser, so the workflow hangs until it times out.

  ## Fix

  `--headless` ensures chainctl uses the device flow fallback instead of
  browser-based auth. This only affects the failure path — when `--identity`
  succeeds via ambient credentials (the normal CI path), `--headless` is
  never exercised.

  ## Risk

  None. The `--headless` flag only changes behavior when ambient credential
  detection fails, which is already a failure case. Normal `--identity`
  authentication via GitHub Actions OIDC is unaffected.


  🤖 Generated with [Claude Code](https://claude.com/claude-code)