### PR TITLE
feat(harden-runner): move to inline block policies

### DIFF
--- a/.github/workflows/auth.yaml
+++ b/.github/workflows/auth.yaml
@@ -23,7 +23,14 @@ jobs:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            console-api.enforce.dev:443
+            dl.enforce.dev:443
+            github.com:443
+            issuer.enforce.dev:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,17 @@ jobs:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            c.pki.goog:80
+            dl.enforce.dev:443
+            github.com:443
+            o.pki.goog:80
+            ocsp.pki.goog:80
+            ocsp.sectigo.com:80
+            updates.cdn-apple.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./


### PR DESCRIPTION
This PR moves harden-runner to block mode similar to other repositories. The endpoints are derived from stable baseline data in StepSecurity and should be representative of the usual activity for these Workflows.