### PR TITLE
fix(ci): harden against template injection and credential exposure

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     groups:
       actions:

--- a/.github/workflows/auth.yaml
+++ b/.github/workflows/auth.yaml
@@ -33,6 +33,8 @@ jobs:
             issuer.enforce.dev:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
         with:
           identity: ce2d1984a010471142503340d670612d63ffb9f6/d05d31ba65ec54d1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,5 +45,7 @@ jobs:
             updates.cdn-apple.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./
       - run: chainctl version

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -44,3 +44,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true

--- a/action.yaml
+++ b/action.yaml
@@ -97,7 +97,7 @@ runs:
         CURL_RETRY_ALL_ERRORS: ${{ inputs.retry-all-errors }}
         ENVIRONMENT: ${{ inputs.environment }}
       run: |
-        cd $(mktemp -d)
+        cd "$(mktemp -d)" || exit
 
         # Massage GitHub's values to the ones we expect.
         # https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
@@ -128,7 +128,7 @@ runs:
           curl -o ./${out} -fsL --retry 5 --retry-delay 1 --retry-all-errors "${url}"
         fi
         chmod +x ./${out}
-        echo "$(pwd)" >> $GITHUB_PATH
+        echo "$(pwd)" >> "$GITHUB_PATH"
 
         # Print the version of chainctl installed
         ./${out} version
@@ -177,7 +177,7 @@ runs:
 
         if [ "$EXPORT_AUTH" == "true" ]; then
           echo "::group::Exporting HTTP_AUTH environment variable for $APK_HOST"
-          echo HTTP_AUTH="basic:${APK_HOST}:user:$(chainctl auth token --audience "$APK_HOST")" >> $GITHUB_ENV
+          echo HTTP_AUTH="basic:${APK_HOST}:user:$(chainctl auth token --audience "$APK_HOST")" >> "$GITHUB_ENV"
           echo "::endgroup::"
         fi
 
@@ -209,7 +209,7 @@ runs:
           exit 1
         fi
         if [ "$EXPORT_AUTH" == "true" ]; then
-          echo HTTP_AUTH="basic:${APK_HOST}:user:$(chainctl auth token --audience "$APK_HOST")" >> $GITHUB_ENV
+          echo HTTP_AUTH="basic:${APK_HOST}:user:$(chainctl auth token --audience "$APK_HOST")" >> "$GITHUB_ENV"
         fi
 
     - if: ${{ inputs.setup-python-keyring == 'true' }}

--- a/action.yaml
+++ b/action.yaml
@@ -95,24 +95,26 @@ runs:
       shell: bash
       env:
         CURL_RETRY_ALL_ERRORS: ${{ inputs.retry-all-errors }}
+        ENVIRONMENT: ${{ inputs.environment }}
       run: |
         cd $(mktemp -d)
 
         # Massage GitHub's values to the ones we expect.
         # https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
-        os=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+        # RUNNER_OS and RUNNER_ARCH are set automatically by the GitHub Actions runner.
+        os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
         if [[ "${os}" == "macos" ]]; then
           os="darwin"
         fi
 
-        arch="${{ runner.arch }}"
+        arch="$RUNNER_ARCH"
         if [[ "${arch}" == "X64" ]]; then
           arch="x86_64"
         elif [[ "${arch}" == "ARM64" ]]; then
           arch="arm64"
         fi
 
-        url="https://dl.${{ inputs.environment }}/chainctl/latest/chainctl_${os}_${arch}"
+        url="https://dl.${ENVIRONMENT}/chainctl/latest/chainctl_${os}_${arch}"
         out="chainctl"
         if [[ "${os}" == "windows" ]]; then
           url="${url}.exe"
@@ -120,7 +122,7 @@ runs:
         fi
         echo "Downloading chainctl from ${url}"
 
-        if [[ "${{ env.CURL_RETRY_ALL_ERRORS }}" != "true" ]]; then
+        if [[ "$CURL_RETRY_ALL_ERRORS" != "true" ]]; then
           curl -o ./${out} -fsL --retry 5 --retry-delay 1 "${url}"
         else
           curl -o ./${out} -fsL --retry 5 --retry-delay 1 --retry-all-errors "${url}"
@@ -140,40 +142,42 @@ runs:
         IDENTITY: ${{ inputs.identity }}
         CHAINCTL_CONFIG: ${{ inputs.config-path }}
         EXPORT_AUTH: ${{ inputs.env-auth }}
+        LIBRARIES_HOST: ${{ inputs.libraries-host }}
+        APK_HOST: ${{ inputs.apk-host }}
       run: |
-        echo "::group::Authenticating with Chainguard as ${{ env.IDENTITY }}"
-        if chainctl auth login --identity "${{ env.IDENTITY }}" -v=${{ env.VERBOSITY }}; then
-          echo Logged in as ${{ env.IDENTITY }}!
+        echo "::group::Authenticating with Chainguard as $IDENTITY"
+        if chainctl auth login --identity "$IDENTITY" -v="$VERBOSITY"; then
+          echo Logged in as "$IDENTITY"!
         else
-          echo "::error Unable to assume the identity ${{ env.IDENTITY }}."
+          echo "::error Unable to assume the identity $IDENTITY."
           exit 1
         fi
         echo "::endgroup::"
 
-        echo "::group::Authenticating with ${{ inputs.libraries-host }} as ${{ env.IDENTITY }}"
-        if ! chainctl auth login --identity "${{ env.IDENTITY }}" --audience ${{ inputs.libraries-host }} -v=${{ env.VERBOSITY }}; then
-          echo "::error Unable to assume the identity ${{ env.IDENTITY }} for ${{ inputs.libraries-host }}."
+        echo "::group::Authenticating with $LIBRARIES_HOST as $IDENTITY"
+        if ! chainctl auth login --identity "$IDENTITY" --audience "$LIBRARIES_HOST" -v="$VERBOSITY"; then
+          echo "::error Unable to assume the identity $IDENTITY for $LIBRARIES_HOST."
           exit 1
         fi
         echo "::endgroup::"
 
-        echo "::group::Authenticating with ${{ inputs.apk-host }} as ${{ env.IDENTITY }}"
-        if ! chainctl auth login --identity "${{ env.IDENTITY }}" --audience ${{ inputs.apk-host }} -v=${{ env.VERBOSITY }}; then
-          echo "::error Unable to assume the identity ${{ env.IDENTITY }} for ${{ inputs.apk-host }}."
+        echo "::group::Authenticating with $APK_HOST as $IDENTITY"
+        if ! chainctl auth login --identity "$IDENTITY" --audience "$APK_HOST" -v="$VERBOSITY"; then
+          echo "::error Unable to assume the identity $IDENTITY for $APK_HOST."
           exit 1
         fi
         echo "::endgroup::"
 
         echo "::group::Registering docker credential helper"
-        if ! chainctl auth configure-docker --identity "${{ env.IDENTITY }}" -v=${{ env.VERBOSITY }}; then
-          echo "::error Unable to register credential helper as ${{ env.IDENTITY }}."
+        if ! chainctl auth configure-docker --identity "$IDENTITY" -v="$VERBOSITY"; then
+          echo "::error Unable to register credential helper as $IDENTITY."
           exit 1
         fi
         echo "::endgroup::"
 
-        if [ "${{ env.EXPORT_AUTH }}" == "true" ]; then
-          echo "::group::Exporting HTTP_AUTH environment variable for ${{ inputs.apk-host }}"
-          echo HTTP_AUTH="basic:${{ inputs.apk-host }}:user:$(chainctl auth token --audience ${{ inputs.apk-host }})" >> $GITHUB_ENV
+        if [ "$EXPORT_AUTH" == "true" ]; then
+          echo "::group::Exporting HTTP_AUTH environment variable for $APK_HOST"
+          echo HTTP_AUTH="basic:${APK_HOST}:user:$(chainctl auth token --audience "$APK_HOST")" >> $GITHUB_ENV
           echo "::endgroup::"
         fi
 
@@ -187,24 +191,25 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
         AUDIENCE: ${{ inputs.audience }}
         EXPORT_AUTH: ${{ inputs.env-auth }}
+        APK_HOST: ${{ inputs.apk-host }}
       run: |
         echo "::warning::The use of invite codes with Github actions is deprecated, use assumed identities instead."
 
-        AUDIENCE="${{ env.AUDIENCE }}"
-        if [[ -z "${AUDIENCE}" ]]; then
-          AUDIENCE=issuer.${{ env.ENVIRONMENT }}
+        AUDIENCE_VAL="$AUDIENCE"
+        if [[ -z "${AUDIENCE_VAL}" ]]; then
+          AUDIENCE_VAL="issuer.${ENVIRONMENT}"
         fi
-        IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${AUDIENCE}" | jq -r '.value')
+        IDTOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${AUDIENCE_VAL}" | jq -r '.value')
 
         # This will start failing once the invite code expires, which is why we have the login guard.
-        if chainctl auth login --create-group=false --identity-token "${IDTOKEN}" --invite-code="${CHAINGUARD_INVITE_CODE}" -v=${{ env.VERBOSITY }}; then
+        if chainctl auth login --create-group=false --identity-token "${IDTOKEN}" --invite-code="${CHAINGUARD_INVITE_CODE}" -v="$VERBOSITY"; then
           echo Logged in!
         else
           echo Failed to log in with invite code
           exit 1
         fi
-        if [ "${{ env.EXPORT_AUTH }}" == "true" ]; then
-          echo HTTP_AUTH="basic:${{ inputs.apk-host }}:user:$(chainctl auth token --audience ${{ inputs.apk-host }})" >> $GITHUB_ENV
+        if [ "$EXPORT_AUTH" == "true" ]; then
+          echo HTTP_AUTH="basic:${APK_HOST}:user:$(chainctl auth token --audience "$APK_HOST")" >> $GITHUB_ENV
         fi
 
     - if: ${{ inputs.setup-python-keyring == 'true' }}


### PR DESCRIPTION
## Summary

This patch series addresses GitHub Actions security findings from the PSEC-923 sweep of
`chainguard-dev/setup-chainctl`. Four commits are included. Two findings
(`dangerous-triggers`, `github-env`) require human judgment and are documented in
`manual-review.md` only.

## Patches

### 0001 — fix(ci): resolve template injection findings in action.yaml

Fixes all 36 `template-injection` findings, concentrated in the composite `action.yaml`
at the root of this repository. The action has three `run:` blocks; all were using
inline `${{ inputs.* }}`, `${{ runner.* }}`, and `${{ env.* }}` expressions directly in
shell code.

**Step "Install chainctl"** (lines 94–132): Added `ENVIRONMENT: ${{ inputs.environment }}`
to the existing `env:` block to cover the `inputs.environment` inline expansion. Replaced
`${{ runner.os }}` and `${{ runner.arch }}` with the built-in `$RUNNER_OS` and
`$RUNNER_ARCH` env vars that the GitHub Actions runner provides automatically — no extra
`env:` entries needed for those. Also replaced `${{ env.CURL_RETRY_ALL_ERRORS }}` with
`$CURL_RETRY_ALL_ERRORS`.

**Step "Authenticate with Chainguard (assumed identity)"** (lines 134–178): Added two
env vars to the existing `env:` block:
- `LIBRARIES_HOST: ${{ inputs.libraries-host }}`
- `APK_HOST: ${{ inputs.apk-host }}`

Replaced all remaining `${{ env.IDENTITY }}`, `${{ env.VERBOSITY }}`,
`${{ env.EXPORT_AUTH }}`, `${{ inputs.libraries-host }}`, and `${{ inputs.apk-host }}`
inline expansions with `$VAR` shell references. Also quoted `-v="$VERBOSITY"` arguments
that were previously unquoted (`-v=${{ env.VERBOSITY }}`).

**Step "Authenticate with Chainguard (DEPRECATED invite-code)"** (lines 180–208): Added
`APK_HOST: ${{ inputs.apk-host }}` to the existing `env:` block. Replaced all remaining
`${{ env.* }}` and `${{ inputs.apk-host }}` inline expansions. Renamed the shell-local
`AUDIENCE` variable to `AUDIENCE_VAL` to avoid clobbering the env var `AUDIENCE` that
is set from `inputs.audience` in the same step.

All `env:` blocks were already present before the fix; no placement changes were needed.
All shell references use double-quoted `"$VAR"` form.

### 0002 — fix(ci): add persist-credentials: false to checkout steps

Fixes 2 `artipacked` findings:

- `.github/workflows/auth.yaml` — checkout followed only by `./` (the composite action
  under test) and `chainctl auth status`. No downstream git operations use the credential
  store. `persist-credentials: false` is correct.

- `.github/workflows/test.yaml` — checkout followed only by `./` and `chainctl version`.
  No downstream git operations. `persist-credentials: false` is correct.

### 0003 — fix(ci): add pedantic persona, zizmor.yml suppressions, and dependabot cooldown

Three related configuration changes:

- **`.github/workflows/zizmor.yaml`**: Adds `persona: pedantic` to the `zizmor-action`
  step so that CI catches all template expansion findings, not only those from
  demonstrably attacker-controlled sources.

- **`.github/zizmor.yml`** (new file): Suppresses four pedantic-only rules that have
  no exploitable security impact:
  - `concurrency-limits` — 4 findings; low security value
  - `anonymous-definition` — cosmetic/style only
  - `undocumented-permissions` — documentation style only
  - Also sets `dependabot-cooldown: days: 3` to match the cooldown added to `dependabot.yaml`

- **`.github/dependabot.yaml`**: Adds `cooldown: default-days: 3` to prevent dependency
  churn from same-day upstream releases that may not yet have full test coverage.

### 0004 — fix(ci): resolve shellcheck findings in action.yaml

Fixes three shellcheck findings in the composite `action.yaml` that were not covered by
the template-injection patch:

- **SC2046 + SC2164** (`cd $(mktemp -d)`, line 99): Quoted the subshell and added
  `|| exit` so a failed `cd` does not silently continue execution in the wrong directory.
- **SC2086** (`>> $GITHUB_PATH`, line 129): Quoted the environment file path in the
  append redirection.
- **SC2086** (`>> $GITHUB_ENV`, lines 181 and 213): Quoted the environment file path in
  the two `HTTP_AUTH` append redirections (one in the assumed-identity step, one in the
  DEPRECATED invite-code step).

## Findings Not Patched

### `dangerous-triggers` — `auth.yaml` uses `pull_request_target` with `id-token: write`

Documented in `manual-review.md`. This requires human judgment about the intended
authentication testing workflow. The risk is real: any fork PR triggers an OIDC token
request for the hardcoded Chainguard identity. Options include switching to `pull_request`
+ GitHub environment protection, adding same-repo guards, or splitting into push-only
auth testing.

### `github-env` — Three findings in `action.yaml`

Documented in `manual-review.md`:

1. `action.yaml:129` — `echo "$(pwd)" >> $GITHUB_PATH`: The path is a mktemp directory,
   not attacker-controlled. **Low risk; no fix needed** (the unquoted `$GITHUB_PATH` was
   addressed by SC2086 fix in 0004, but the underlying `github-env` finding remains in
   scope for zizmor).

2. `action.yaml:181` — Writing `HTTP_AUTH` with APK token to `$GITHUB_ENV` in the
   assumed-identity step. The `APK_HOST` value is caller-supplied. Recommend validating
   `APK_HOST` and masking the token. **Medium risk.**

3. `action.yaml:213` — Same pattern in the DEPRECATED invite-code step. **Medium risk.**
   Best resolved by completing migration of callers away from invite codes.

## Statistics

| Finding | Count | Action |
|---------|-------|--------|
| `template-injection` | 36 | Fixed in 0001 |
| `artipacked` | 2 | Fixed in 0002 |
| `concurrency-limits` | 4 | Suppressed in 0003 (no security impact) |
| `dependabot-cooldown` | 1 | Addressed in 0003 |
| shellcheck (SC2046/SC2164/SC2086) | 4 | Fixed in 0004 |
| `github-env` | 3 | Manual review only |
| `dangerous-triggers` | 1 | Manual review only |

## References

- Campaign: PSEC-923
- zizmor version: 1.24.1
- Sweep date: 2026-05-02